### PR TITLE
Fix invalid xeya links.

### DIFF
--- a/saber-config.js
+++ b/saber-config.js
@@ -45,8 +45,8 @@ module.exports = {
 
             ],
             Reference: [
-                { label: "Commands", href: "https://essinfo.xeya.me/index.php?page=commands" },
-                { label: "Permissions", href: "https://essinfo.xeya.me/index.php?page=permissions" },
+                { label: "Commands", href: "https://essinfo.xeya.me/commands.html" },
+                { label: "Permissions", href: "https://essinfo.xeya.me/permissions.html" },
                 { label: "Changelogs", link: "https://github.com/EssentialsX/Essentials/releases" }
             ]
         }


### PR DESCRIPTION
The links https://essinfo.xeya.me/index.php?page=commands and https://essinfo.xeya.me/index.php?page=permissions do (no longer) work, so I replaced them with the actual links.