### PR TITLE
Change link to href

### DIFF
--- a/saber-config.js
+++ b/saber-config.js
@@ -47,7 +47,7 @@ module.exports = {
             Reference: [
                 { label: "Commands", href: "https://essinfo.xeya.me/commands.html" },
                 { label: "Permissions", href: "https://essinfo.xeya.me/permissions.html" },
-                { label: "Changelogs", link: "https://github.com/EssentialsX/Essentials/releases" }
+                { label: "Changelogs", href: "https://github.com/EssentialsX/Essentials/releases" }
             ]
         }
     },


### PR DESCRIPTION
The Changelog used `link` which caused the URL to turn into https://essentialsx.net/wiki/https:/github.com/EssentialsX/Essentials/releases

This PR fixes this by changing it to `href`