### PR TITLE
Update Information of Mohist Page: This Page is telling lies. 

### DIFF
--- a/pages/do-not-use-mohist.md
+++ b/pages/do-not-use-mohist.md
@@ -83,9 +83,7 @@ alongside Forge mods. SpongeAPI is designed to support the nuances of modded pla
 work seamlessly with Forge mods - for example, [Nucleus](https://v2.nucleuspowered.org/) includes almost every feature
 of EssentialsX and more, and is 100% compatible with mods. Many Bukkit plugins also have equivalent Sponge ports, and
 some (such as [LuckPerms](https://luckperms.net/)) even allow you to use your existing Bukkit data when you switch to
-Sponge.
-
-For newer versions of Minecraft, SpongeForge currently isn't available. However, there is a wide selection of
+Sponge. Unfortunately, [Nucleus](https://v2.nucleuspowered.org/) has reached end-of-life, but consider that there is a wide selection of
 server-side mods for Forge and Fabric that can replace plugins, which you can find sites like on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ftb-essentials-forge)
 and [Modrinth](https://modrinth.com/mods). For example, [FTB Essentials](https://www.curseforge.com/minecraft/mc-mods/ftb-essentials-forge)
 for Forge includes features similar to EssentialsX, while [FTB Chunks](https://www.curseforge.com/minecraft/mc-mods/ftb-chunks-forge)

--- a/pages/do-not-use-mohist.md
+++ b/pages/do-not-use-mohist.md
@@ -1,21 +1,12 @@
 ---
 layout: page-with-hero
-title: "PSA: Do not use Mohist."
-subtitle: "A warning about malicious behaviour and the dangers of running untrusted code."
+title: "PSA: it is not recommended to use Mohist."
 ---
-
+*Note: this Page Is Now Not in effect as https://github.com/Shawiizz/MohistEssentialsX/*
 *Note: this PSA is not about whether or not we will help you if you run Mohist. That question is answered on the
 official EssentialsX downloads page and changelogs.  
 This PSA is about security and dangerous behaviour by the Mohist project.*
 
-It has come to our attention that as of [10th April 2021](https://github.com/MohistMC/Mohist/commit/58bbb1c8a13dcbf764c11668287e6fb85a884b3a),
-**Mohist tricks users into deleting official plugin jars and installing unofficial modified builds.** Not only is this
-behaviour shady, but it also poses significant risk to users who don't know what software they're running.
-
-As a result, we strongly recommend that you **do not use or support the Mohist project in any way going forwards.**
-We cannot guarantee the safety or functionality of unofficial builds of EssentialsX, and you should avoid using Mohist
-where possible. There are countless alternatives that are safer and more functional, and these alternatives are listed
-at the bottom of this page.
 
 ### Context
 
@@ -48,29 +39,6 @@ API is designed to function:
   though this class is supposed to wrap around the underlying player entity and update when it changes*! This broke
   the majority of EssentialsX, as the `Player` we use becomes detached from the actual server whenever someone dies.
 
-These changes (and likely others too) consequently break several plugins, including but not limited to EssentialsX.
-Despite being warned that these are breaking changes and will cause issues, the Mohist project has refused to fix their
-implementation of Bukkit, and instead has employed further workarounds to hide issues with plugins.
-
-#### Mohist's dangerous "plugin checker"
-
-On [10th April 2021](https://github.com/MohistMC/Mohist/commit/58bbb1c8a13dcbf764c11668287e6fb85a884b3a), Mohist added
-a "plugin checker", which scans for plugins that Mohist breaks and shows the following message:
-
-![Screenshot of Mohist warning message](https://cdn.discordapp.com/attachments/762376197308547082/851490309585502269/unknown.png)
-
-Not only is this message misleading (implying that EssentialsX is at fault when the real issue is on Mohist's end), but
-it tricks users into **deleting the software they downloaded from a trusted source** and **running arbitrary code**
-from an unknown source, *without telling the user what is wrong with the plugin they downloaded, how the "correct
-version" is any better, or where the "correct" version even originates from*. Many users who see this prompt will not
-understand that Mohist is downloading and running arbitrary modified code instead of the official plugin jars they
-downloaded. Furthermore, this mechanism could very easily be abused to download malware, hidden behind the names of
-other well-known projects and using the excuse of "fixes".
-
-There are several better ways the Mohist team can rectify their issues, but the correct way is this: **write a
-compliant Bukkit API implementation**. Other similar projects already achieve this, *without* relying on tricking users
-into downloading and executing unknown code. Mohist's decision to mislead users into downloading untrusted code shows
-that they do not care about the security of their users.
 
 ### Alternatives to Mohist and hybrid servers
 


### PR DESCRIPTION
Nucleus Has Reached end of Life.
at Readme, it says:
"This project is no longer active."
This Means It's become dead project and Archived! 

From Part of ```README.md```:

Nucleus v3
====

**This project is no longer active. You are welcome to fork under the terms of the MIT licence under a different name.**
This information is outdated, plus, every information is Very outdated! all of the Information No Longer Make Sense. Mohist Don't need Modified Plugins Anymore. 
From Developer of Mohist: 

![image](https://github.com/EssentialsX/Website/assets/167604853/1ea8c676-9dcd-4888-92e9-761df602587e)

We now know it, this text was not clear and we are sorry for that, it was not our intention. As you may know, our team does not contain any native English speakers, so it is difficult for us to write clear messages, even though we make every effort to make it as clear as possible to everyone. Fortunately, our community has been able to help us correct this problem.

Actually, this text doesn't mean the bug comes from EssentialsX. It means the plugin cannot work due to an incompatibility on Mohist's side and ask the user if he allows the Mohist software to download a modified version of this plugin (temporarily) to make it work fine with Mohist, and I insist on the fact that it requires the user's agreement and that it has always been the case. Also EssentialsX is properly fixed in Mohist and doesn't need the modified plugin anymore for a long time.

Secondly, Mohist never run any untrusted code as the code of modified plugins is always published on GitHub and shows what has been modified in the plugin's code. That message actually misses some information, like the repository URL, what has been changed and fixed, etc., and it has been [fixed there](https://github.com/MohistMC/Mohist/commit/04270a57b30f5de902409b524ad682c790c70657). This is explained in our Discord server, but not everyone can go to our Discord server and we solved this problem by adding more details to that message, and we hope it is now clearer for everyone.

Plus, know that we never and will never use this plugin checker to download anything malicious. You are free to check what is downloaded with the plugin checker as [Mohist is free and open source on GitHub](https://github.com/MohistMC/Mohist/), fixed plugins source code is always published in GitHub and you can also decide if you want to download the modified plugin or not. And to finish, you can even disable the plugin checker by setting disable_plugins_blacklist to true in mohist-config/mohist.yml
Please Refrain from Writing The Untrusted/No longer trusted Information. Mohist is not Malicious. 
You Didn't Consider the Warning Message.
```
[WARN] The Plugin EssentialsX-2.18.2.0(1) Cannot work Properly. You Should Use The Version 2.19.0-dev+99-fd961d5.  < This is Already Fixed because There is No Native English Speaker In Mohist Team 
You Can Disable this warn by typing disable_plugins_blacklist to true. < True.
do you want to download the correct version of EssentialsX-2.18.2.0 (1)? < This is Already Fixed because There is No Native English Speaker In Mohist Team. 
type yes or no. < they can type no if they don't want to and set disable-plugin-blacklist to true. Plus, after that, they Can Upgrade Mohist version and put latest EssentialsX. Makes no Sense at all!
```
but before merging, this will open as a draft until i add the info from [Shawiizz's Truth About Do-Not-Use-Mohist.md](https://github.com/Shawiizz/MohistEssentialsX/) and pushing it. i will notify you after i done that.
![image](https://github.com/EssentialsX/Website/assets/167604853/21ecc7bd-e8c3-4dd8-94b7-ec419e502fa7)
