### PR TITLE
fix: broken links on Frequently Asked Questions page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,7 @@
                         </div>
                         <div class="tile is-child">
                             <h2>All you can eat, and then some.</h2>
-                            <p>With over <a href="https://essinfo.xeya.me/commands.php">130 commands</a>, EssentialsX provides one of the most comprehensive feature sets out there, providing teleportation, moderation tools, gameplay enhancements and more.</p>
+                            <p>With over <a href="https://essinfo.xeya.me/commands.html">130 commands</a>, EssentialsX provides one of the most comprehensive feature sets out there, providing teleportation, moderation tools, gameplay enhancements and more.</p>
                             <p>Just want the homes and warps? Great. Need a sign shop? Done. Want complex and rich kits with enchantments, custom books and lore? Sorted.</p>
                             <p>Whether you're a small group of friends or a huge server with hundreds of players, we've got the basics covered.</p>
                             <saber-link class="button is-primary is-rounded" to="/wiki/Home.html">Visit the wiki</saber-link>

--- a/pages/wiki/Common-Issues.md
+++ b/pages/wiki/Common-Issues.md
@@ -29,7 +29,7 @@ aliases:
     - "essentials:msg $1-"
 ```
 
-See the [Bukkit wiki page](https://bukkit.gamepedia.com/Commands.yml#aliases) for more information.
+See the [Bukkit wiki page](https://bukkit.fandom.com/wiki/Commands.yml#aliases) for more information.
 
 ## Another plugin is overriding an EssentialsX command
 Typically, if EssentialsX finds another plugin providing a command with the same name as one of EssentialsX's own commands, it will try and hand over that command to the other plugin. However, you can force EssentialsX to handle commands that are also provided by another plugin using the [`overridden-commands` section](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/main/resources/config.yml#L162) of your `config.yml`. This will tell EssentialsX not to "give up" the command to the other plugin.

--- a/pages/wiki/Common-Issues.md
+++ b/pages/wiki/Common-Issues.md
@@ -43,7 +43,7 @@ overridden-commands:
 Note that in some cases, you may also need to alias the command to the `essentials:` version of the command. [See above](https://github.com/EssentialsX/Essentials/wiki/Common-Issues#essentialsx-overrides-a-command-from-spigot-or-another-plugin) for details. In addition, if you have a plugin running on your proxy ([BungeeCord](https://www.spigotmc.org/wiki/bungeecord/)/[Waterfall](https://github.com/PaperMC/Waterfall) or [Velocity](https://velocitypowered.com)), the command may not even reach the server. EssentialsX can't do anything about this - you need to fix this on the proxy.
 
 ## Tab completion doesn't work for commands that override an EssentialsX command
-**Related issues: [#1384](/EssentialsX/Essentials/issues/1384)**  
+**Related issues: [#1384](https://github.com/EssentialsX/Essentials/issues/1384)**  
 You can alias the command to the version from the other plugin, which should fix tab complete behaviour - see above.
 
 ## I need help with GroupManager! <br /> Where's the updated GroupManager?

--- a/pages/wiki/Common-Issues.md
+++ b/pages/wiki/Common-Issues.md
@@ -12,7 +12,7 @@ In this example, the `[balance]` sign is enabled but the `[buy]` sign is not.
 Note that enabling `color` means that players will be allowed to use color codes in the sign text, but still requires that another sign type is enabled.
 
 ## EssentialsX overrides a command from Spigot or another plugin
-**Related issues: [#1458](/EssentialsX/Essentials/issues/1458)**  
+**Related issues: [#1458](https://github.com/EssentialsX/Essentials/issues/1458)**  
 You can create an alias for commands using Bukkit's `commands.yml` file, which should be in your server root.
 
 The example below does the following:

--- a/pages/wiki/Improvements.md
+++ b/pages/wiki/Improvements.md
@@ -170,7 +170,7 @@ Players have the ability to disable any and all payment via the `/paytoggle` com
 `payoff` will always disable payments to prevent errors. On the contrary, `payon` will always enable payments.
 
 ### Command confirmations for `/pay` and `/clearinventory`
-_Requested in [#1032](/drtshock/Essentials/issues/1032); added in [5f83766](https://github.com/drtshock/Essentials/commit/5f83766)._
+_Requested in [#1032](https://github.com/EssentialsX/Essentials/issues/1032); added in [5f83766](https://github.com/drtshock/Essentials/commit/5f83766)._
 
 You can now specify whether players are prompted to confirm `/clearinventory` and `/pay` commands before they are executed using the `default-enabled-confirm-commands` section of the config.
 
@@ -183,7 +183,7 @@ This feature was implemented in ([0a563b9](https://github.com/drtshock/Essential
 This feature introduces the `teleport-to-center` configuration feature. When set to `true` (default), all teleportations are centered to the block; technically, setting the x and z coordinate decimals to .5 and .5. When `teleport-to-center` is set to `false`, all teleports are performed to the exact location as given.
 
 ### Mail chat formatting
-_Requested in [#1560](/drtshock/Essentials/issues/1560); added in [665229b](https://github.com/drtshock/Essentials/commit/665229b)._
+_Requested in [#1560](https://github.com/EssentialsX/Essentials/issues/1560); added in [665229b](https://github.com/drtshock/Essentials/commit/665229b)._
 
 This feature introduces the ability to format `/mail` messages using `&` formatting codes - [click here](/wiki/Color-Permissions.html) for more information.
 


### PR DESCRIPTION
Issue i made #108 

I went through some of the archives and found the issue pages that were broken on the FAQ page for the website, and have fixed them with the appropriate links. This should help server users in the future who are looking for those links, especially useful pages like the essentials commands page, which has been a broken link for a while.

For instance 

- https://github.com/EssentialsX/Essentials/issues/1458
- https://github.com/EssentialsX/Essentials/issues/1384

Also fixed commands.php page, which has since been replaced by https://essinfo.xeya.me/commands.html

![image](https://github.com/user-attachments/assets/bf43f569-ce16-4fec-8812-df3c49cae0e9)
![image](https://github.com/user-attachments/assets/6c85594c-e66f-4a0e-9197-92a63d69de63)
